### PR TITLE
Remove excess Slack chatter

### DIFF
--- a/src/Discourse/Event/DiscoursePost.php
+++ b/src/Discourse/Event/DiscoursePost.php
@@ -46,6 +46,11 @@ class DiscoursePost
 
         $post = $this->payload['post'];
 
+        // Only report NEW topics, not comments on existing topics
+        if (isset($post['id']) && $post['id'] > 1) {
+            return false;
+        }
+
         if (array_key_exists('hidden', $post) && $post['hidden']) {
             return false;
         }

--- a/src/Discourse/Event/DiscoursePost.php
+++ b/src/Discourse/Event/DiscoursePost.php
@@ -16,10 +16,6 @@ class DiscoursePost
 {
     // phpcs:disable
     private const AUTHOR_ICON = 'https://slack-imgs.com/?c=1&o1=wi16.he16&url=https%3A%2F%2Fdiscourse-meta.s3-us-west-1.amazonaws.com%2Foriginal%2F3X%2Fc%2Fb%2Fcb4bec8901221d4a646e45e1fa03db3a65e17f59.png';
-
-    private const COLOR = '#295473';
-
-    private const FOOTER_ICON = 'https://slack-imgs.com/?c=1&o1=wi16.he16&url=https%3A%2F%2Fdiscourse-meta.s3-us-west-1.amazonaws.com%2Foriginal%2F3X%2Fc%2Fb%2Fcb4bec8901221d4a646e45e1fa03db3a65e17f59.png';
     // phpcs:enable
 
     /** @var string */

--- a/src/Discourse/Middleware/DiscourseHandler.php
+++ b/src/Discourse/Middleware/DiscourseHandler.php
@@ -34,11 +34,15 @@ class DiscourseHandler implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $this->dispatcher->dispatch(new DiscoursePost(
+        $post = new DiscoursePost(
             $request->getAttribute('channel'),
             $request->getParsedBody(),
             $this->discourseUrl
-        ));
+        );
+
+        if ($post->isValidForSlack()) {
+            $this->dispatcher->dispatch($post);
+        }
 
         return $this->responseFactory->createResponse(202);
     }

--- a/src/GitHub/Event/GitHubIssue.php
+++ b/src/GitHub/Event/GitHubIssue.php
@@ -42,9 +42,9 @@ final class GitHubIssue extends AbstractGitHubEvent
 
     public function ignore(): bool
     {
+        // Previously, also included 'closed'
         return ! in_array($this->payload['action'], [
             'opened',
-            'closed',
             'reopened',
         ], true);
     }

--- a/src/GitHub/Event/GitHubIssueComment.php
+++ b/src/GitHub/Event/GitHubIssueComment.php
@@ -13,6 +13,8 @@ use function sprintf;
 use function ucfirst;
 
 /**
+ * This event type is no longer used.
+ *
  * @see https://developer.github.com/v3/activity/events/types/#issuecommentevent
  */
 class GitHubIssueComment extends AbstractGitHubEvent

--- a/src/GitHub/Event/GitHubPullRequest.php
+++ b/src/GitHub/Event/GitHubPullRequest.php
@@ -42,9 +42,9 @@ final class GitHubPullRequest extends AbstractGitHubEvent
 
     public function ignore(): bool
     {
+        // Previously, also included "closed"
         return ! in_array($this->payload['action'], [
             'opened',
-            'closed',
             'reopened',
         ], true);
     }

--- a/src/GitHub/Event/GitHubStatus.php
+++ b/src/GitHub/Event/GitHubStatus.php
@@ -21,14 +21,30 @@ use function substr;
  */
 final class GitHubStatus extends AbstractGitHubEvent
 {
+    /**
+     * Patterns for build contexts we're interested in.
+     *
+     * @var string[]
+     */
     private const CONTEXT_PATTERNS = [
+        '#coveralls#',
         '#^github#',
         '#travis-ci#',
-        '#coveralls#',
     ];
 
+    /**
+     * Specific states we are interested in reporting.
+     *
+     * Since the main purpose of reporting to github is to allow taking action,
+     * we only report failures and errors.
+     *
+     * Previous entries included:
+     *
+     * - 'success'
+     *
+     * @var string[]
+     */
     private const STATES_ALLOWED = [
-        'success',
         'failure',
         'error',
     ];

--- a/src/GitHub/Listener/GitHubIssueCommentListener.php
+++ b/src/GitHub/Listener/GitHubIssueCommentListener.php
@@ -9,6 +9,9 @@ use App\Slack\Domain\Block;
 use App\Slack\Domain\WebAPIMessage;
 use App\Slack\SlackClientInterface;
 
+/**
+ * This listener is no longer used, as we no longer handle comment events.
+ */
 class GitHubIssueCommentListener
 {
     /** @var string */

--- a/src/GitHub/Middleware/GitHubRequestHandler.php
+++ b/src/GitHub/Middleware/GitHubRequestHandler.php
@@ -36,10 +36,6 @@ class GitHubRequestHandler implements RequestHandlerInterface
                 $message = new Event\GitHubIssue($payload);
                 break;
 
-            case 'issue_comment':
-                $message = new Event\GitHubIssueComment($payload);
-                break;
-
             case 'pull_request':
                 $message = new Event\GitHubPullRequest($payload);
                 break;

--- a/test/Discourse/Listener/DiscoursePostListenerTest.php
+++ b/test/Discourse/Listener/DiscoursePostListenerTest.php
@@ -38,7 +38,14 @@ class DiscoursePostListenerTest extends TestCase
         $this->assertNull($listener($post));
     }
 
-    public function testSendsRequestToSlackApiUsingPostDetailsWhenPostIsValid(): void
+    public function validPostIds(): iterable
+    {
+        yield 'null' => [null];
+        yield 'first' => [1];
+    }
+
+    /** @dataProvider validPostIds */
+    public function testSendsRequestToSlackApiUsingPostDetailsWhenPostIsValid(?int $id): void
     {
         $timestamp = time();
         $response  = $this->prophesize(SlackResponseInterface::class)->reveal();
@@ -51,7 +58,7 @@ class DiscoursePostListenerTest extends TestCase
                 'deleted_at'  => null,
                 'topic_slug'  => 'how-to-do-something',
                 'topic_id'    => 11111111,
-                'id'          => 5,
+                'id'          => $id,
                 'topic_title' => 'How to do something',
                 'username'    => 'somebody',
                 'name'        => 'Some Body',

--- a/test/Discourse/Middleware/DiscourseHandlerTest.php
+++ b/test/Discourse/Middleware/DiscourseHandlerTest.php
@@ -59,6 +59,10 @@ class DiscourseHandlerTest extends TestCase
             ->dispatch(Argument::that(function ($post) use ($id) {
                 TestCase::assertInstanceOf(DiscoursePost::class, $post);
                 TestCase::assertSame('#qanda', $post->getChannel());
+                // Discourse sends either an ID of 1, or no ID at all when
+                // sending a payload indicating a new topic. For
+                // consistency, we treat "no ID" as "1", which is the topic
+                // post (versus a comment post on the topic)
                 TestCase::assertSame(
                     sprintf('https://discourse.laminas.dev/t/some-topic/42/%d', $id ?: 1),
                     $post->getPostUrl()

--- a/test/Discourse/Middleware/DiscourseHandlerTest.php
+++ b/test/Discourse/Middleware/DiscourseHandlerTest.php
@@ -18,7 +18,66 @@ use function date;
 
 class DiscourseHandlerTest extends TestCase
 {
-    public function testDispatchesDiscoursePostAndReturnsEmpty202Response(): void
+    public function validPostIds(): iterable
+    {
+        yield 'null' => [null];
+        yield 'first' => [1];
+    }
+
+    /** @dataProvider validPostIds */
+    public function testDispatchesDiscoursePostWithValidIdAndReturnsEmpty202Response(?int $id): void
+    {
+        /** @var ServerRequestInterface|ObjectProphecy $request */
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('channel')->willReturn('qanda')->shouldBeCalled();
+
+        $now = date('r');
+        $request
+            ->getParsedBody()
+            ->willReturn([
+                'post' => [
+                    'topic_slug' => 'some-topic',
+                    'topic_id'   => 42,
+                    'id'         => $id,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ],
+            ])
+            ->shouldBeCalled();
+
+        $discourseUrl = 'https://discourse.laminas.dev';
+
+        $response        = $this->prophesize(ResponseInterface::class)->reveal();
+        $responseFactory = $this->prophesize(ResponseFactoryInterface::class);
+        $responseFactory
+            ->createResponse(202)
+            ->willReturn($response)
+            ->shouldBeCalled();
+
+        $dispatcher = $this->prophesize(EventDispatcherInterface::class);
+        $dispatcher
+            ->dispatch(Argument::that(function ($post) use ($id) {
+                TestCase::assertInstanceOf(DiscoursePost::class, $post);
+                TestCase::assertSame('#qanda', $post->getChannel());
+                TestCase::assertSame(
+                    sprintf('https://discourse.laminas.dev/t/some-topic/42/%d', $id ?: 1),
+                    $post->getPostUrl()
+                );
+                TestCase::assertTrue($post->isValidForSlack());
+                return $post;
+            }))
+            ->shouldBeCalled();
+
+        $handler = new DiscourseHandler(
+            $discourseUrl,
+            $dispatcher->reveal(),
+            $responseFactory->reveal()
+        );
+
+        $this->assertSame($response, $handler->handle($request->reveal()));
+    }
+
+    public function testDoesNotDispatchCommentPostButStillReturnsEmpty202Response(): void
     {
         /** @var ServerRequestInterface|ObjectProphecy $request */
         $request = $this->prophesize(ServerRequestInterface::class);
@@ -49,14 +108,8 @@ class DiscourseHandlerTest extends TestCase
 
         $dispatcher = $this->prophesize(EventDispatcherInterface::class);
         $dispatcher
-            ->dispatch(Argument::that(function ($post) {
-                TestCase::assertInstanceOf(DiscoursePost::class, $post);
-                TestCase::assertSame('#qanda', $post->getChannel());
-                TestCase::assertSame('https://discourse.laminas.dev/t/some-topic/42/4242', $post->getPostUrl());
-                TestCase::assertTrue($post->isValidForSlack());
-                return $post;
-            }))
-            ->shouldBeCalled();
+            ->dispatch(Argument::any())
+            ->shouldNotBeCalled();
 
         $handler = new DiscourseHandler(
             $discourseUrl,

--- a/test/GitHub/Middleware/GitHubRequestHandlerTest.php
+++ b/test/GitHub/Middleware/GitHubRequestHandlerTest.php
@@ -86,6 +86,7 @@ class GitHubRequestHandlerTest extends TestCase
             'github_app_authorization'       => ['github_app_authorization'],
             'gollum'                         => ['gollum'],
             'installation'                   => ['installation'],
+            'issues-closed'                  => ['issues-closed'],
             'issue-comment-created'          => ['comment-created'],
             'label'                          => ['label'],
             'marketplace_purchase'           => ['marketplace_purchase'],
@@ -100,6 +101,8 @@ class GitHubRequestHandlerTest extends TestCase
             'project_card'                   => ['project_card'],
             'project_column'                 => ['project_column'],
             'public'                         => ['public'],
+            'pull_request-closed'            => ['pull-request-closed'],
+            'pull_request-merged'            => ['pull-request-merged'],
             'pull_request_review'            => ['pull_request_review'],
             'pull_request_review_comment'    => ['pull_request_review_comment'],
             'push'                           => ['push'],
@@ -140,11 +143,8 @@ class GitHubRequestHandlerTest extends TestCase
     public function handledRequestProvider(): array
     {
         return [
-            'issues-closed'         => ['issues-closed.json', 'issues', GitHubIssue::class],
             'issues-opened'         => ['issues-opened.json', 'issues', GitHubIssue::class],
             'issues-reopened'       => ['issues-reopened.json', 'issues', GitHubIssue::class],
-            'pull_request-closed'   => ['pull-request-closed.json', 'pull_request', GitHubPullRequest::class],
-            'pull_request-merged'   => ['pull-request-merged.json', 'pull_request', GitHubPullRequest::class],
             'pull_request-opened'   => ['pull-request-opened.json', 'pull_request', GitHubPullRequest::class],
             'pull_request-reopened' => ['pull-request-reopened.json', 'pull_request', GitHubPullRequest::class],
             'release-published'     => ['release-published.json', 'release', GitHubRelease::class],

--- a/test/GitHub/Middleware/GitHubRequestHandlerTest.php
+++ b/test/GitHub/Middleware/GitHubRequestHandlerTest.php
@@ -86,6 +86,7 @@ class GitHubRequestHandlerTest extends TestCase
             'github_app_authorization'       => ['github_app_authorization'],
             'gollum'                         => ['gollum'],
             'installation'                   => ['installation'],
+            'issue-comment-created'          => ['comment-created'],
             'label'                          => ['label'],
             'marketplace_purchase'           => ['marketplace_purchase'],
             'member'                         => ['member'],
@@ -139,7 +140,6 @@ class GitHubRequestHandlerTest extends TestCase
     public function handledRequestProvider(): array
     {
         return [
-            'issue-comment-created' => ['comment-created.json', 'issue_comment', GitHubIssueComment::class],
             'issues-closed'         => ['issues-closed.json', 'issues', GitHubIssue::class],
             'issues-opened'         => ['issues-opened.json', 'issues', GitHubIssue::class],
             'issues-reopened'       => ['issues-reopened.json', 'issues', GitHubIssue::class],

--- a/test/GitHub/Middleware/GitHubRequestHandlerTest.php
+++ b/test/GitHub/Middleware/GitHubRequestHandlerTest.php
@@ -109,6 +109,7 @@ class GitHubRequestHandlerTest extends TestCase
             'security_advisory'              => ['security_advisory'],
             'sponsorship_event'              => ['sponsorship_event'],
             'star'                           => ['star'],
+            'status-success'                 => ['status-success'],
             'team'                           => ['team'],
             'team_add'                       => ['team_add'],
             'watch'                          => ['watch'],
@@ -149,7 +150,6 @@ class GitHubRequestHandlerTest extends TestCase
             'release-published'     => ['release-published.json', 'release', GitHubRelease::class],
             'status-error'          => ['status-error.json', 'status', GitHubStatus::class],
             'status-failure'        => ['status-failure.json', 'status', GitHubStatus::class],
-            'status-success'        => ['status-success.json', 'status', GitHubStatus::class],
         ];
     }
 


### PR DESCRIPTION
Since the bot became active, we're seeing a lot of excess chatter in Slack, which also means the amount of history we store has been decreasing (currently at around 45 days).

Broadly, this patch helps reduce the number of posts the bot makes by trying to only report _actionable_ items.

To help reduce the amount of posts the bot makes, this patch:

- No longer reports to Slack for _successful_ builds. There's generally no action required for a successful build, but a failed build can mean we need to fix something.

- No longer reports when an issue or PR is closed or merged.

- No longer posts issue/PR comments.

- No longer posts Discourse comments (only the original post).