### PR TITLE
fix a missing sprintf placeholder in pull request title

### DIFF
--- a/src/GitHub/Event/GitHubPullRequest.php
+++ b/src/GitHub/Event/GitHubPullRequest.php
@@ -83,7 +83,7 @@ final class GitHubPullRequest extends AbstractGitHubEvent
 
         $blocks = [
             $this->createContextBlock($repo['html_url'], sprintf(
-                '<%s|*[%s] Pull request #%s %s*>',
+                '<%s|*[%s] Pull request %s#%s: %s*>',
                 $pr['html_url'],
                 $action,
                 $repo['full_name'],

--- a/test/GitHub/Event/GitHubPullRequestTest.php
+++ b/test/GitHub/Event/GitHubPullRequestTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AppTest\GitHub\Event;
+
+use App\GitHub\Event\GitHubPullRequest;
+use PHPUnit\Framework\TestCase;
+
+use function end;
+use function reset;
+
+class GitHubPullRequestTest extends TestCase
+{
+    public function testMessageBlocksContainsCorrectContextBlockAdditionalLine(): void
+    {
+        $payload = $this->createValidPayload();
+        $event = new GitHubPullRequest($payload);
+
+        $messageBlocks = $event->getMessageBlocks();
+
+        self::assertCount(3, $messageBlocks);
+        $contextBlock = reset($messageBlocks);
+        self::assertIsArray($contextBlock);
+        self::assertSame('context', $contextBlock['type']);
+        self::assertIsArray($contextBlock['elements']);
+        self::assertCount(3, $contextBlock['elements']);
+        $additionalText = end($contextBlock['elements']);
+        $expectedText = sprintf(
+            '<%s|*[%s] Pull request %s#%s: %s*>',
+            $payload['pull_request']['html_url'],
+            $payload['action'],
+            $payload['repository']['full_name'],
+            $payload['pull_request']['number'],
+            $payload['pull_request']['title']
+        );
+        self::assertSame($expectedText, $additionalText['text']);
+    }
+
+    /**
+     * @return array<string, string|array<string, string|int>>
+     */
+    private function createValidPayload(): array
+    {
+        return [
+            'action' => 'opened',
+            'repository' => [
+                'full_name' => 'laminas/laminas.dev',
+                'html_url' => 'https://github.com/laminas/laminas.dev',
+            ],
+            'pull_request' => [
+                'html_url' => 'https://github.com/laminas/laminas.dev/pull/5',
+                'number' => 5,
+                'title' => 'fix a missing sprintf placeholder in pull request title',
+                'body' => 'This is the PR body',
+            ],
+            'sender' => [
+                'login' => 'Laminas',
+                'html_url' => 'https://github.com/laminas',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

(As discussed in the Laminas Slack)
It seems that in the `sprintf` call in the message block builder for the pull request message a `%s` placeholder is missing. Thus, the PR title is missing in the Slack message.

This PR fixes that.

~I can add a test for that if you want.~ done