### PR TITLE
Bump dependencies, instead of widening ranges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>laminas/.github:renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchDepTypes": ["require"],
+      "rangeStrategy": "bump"
+    }
   ]
 }


### PR DESCRIPTION
This package is an application: widening dependency ranges should **NOT**
be done, and instead, only latest & greatest dependencies should land in it.
This change prevents rolling back to older major releases of some of our
packages.

