### PR TITLE
Update renovate config

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -27,7 +27,7 @@ hooks:
     echo "Current PHP modules:"
     php -m
     echo "Installing platform.sh CLI"
-    curl -sS https://platform.sh/cli/installer | php
+    curl -fsSL https://raw.githubusercontent.com/platformsh/cli/main/installer.sh | bash
     echo "- Setting up configuration"
     rm -f config/development.config.php config/autoload/*.local.php
     mv config/autoload/local.php.dist config/autoload/local.php

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -21,8 +21,9 @@ mounts:
 hooks:
   build: |
     set -e
+    OPENSWOOLE_VERSION=22.0.0
     echo "Installing Swoole extension"
-    bash install-swoole.sh openswoole 22.0.0
+    bash install-swoole.sh openswoole "$OPENSWOOLE_VERSION"
     echo "Current PHP modules:"
     php -m
     echo "Installing platform.sh CLI"

--- a/renovate.json
+++ b/renovate.json
@@ -35,14 +35,16 @@
       "matchStrings": [" OPENSWOOLE_VERSION=(?<currentValue>.*)\\n"],
       "depNameTemplate": "openswoole/ext-openswoole",
       "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "versioningTemplate": "semver-coerced"
     },
     {
       "fileMatch": ["^.platform.app.yaml$"],
       "matchStrings": ["\\ntype: php:(?<currentValue>.*)\\n"],
       "depNameTemplate": "php/php-src",
       "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^php-(?<version>\\d+\\.\\d+)"
+      "extractVersionTemplate": "^php-(?<version>\\d+\\.\\d+)",
+      "versioningTemplate": "semver-coerced"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,7 @@
     {
       "matchFiles": [".platform.app.yaml"],
       "matchDepNames": ["openswoole/ext-openswoole"],
+      "extends": [":automergeDisabled", ":automergePr", ":label(Awaiting Maintainer Response)"],
       "prBodyNotes": [
         ":warning: CI does not verify if extension can be built successfully or compatible. Build log review at platform.sh is required."
       ]
@@ -23,6 +24,7 @@
     {
       "matchFiles": [".platform.app.yaml"],
       "matchDepNames": ["php/php-src"],
+      "extends": [":automergeDisabled", ":automergePr", ":label(Awaiting Maintainer Response)"],
       "groupName": "PHP",
       "prBodyNotes": [
         ":warning: PHP version might not be available at platform.sh. See https://docs.platform.sh/languages/php.html#supported-versions"

--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,23 @@
     },
     {
       "matchPackageNames": ["php"],
-      "rangeStrategy": "replace"
+      "rangeStrategy": "replace",
+      "groupName": "PHP"
+    },
+    {
+      "matchFiles": [".platform.app.yaml"],
+      "matchDepNames": ["openswoole/ext-openswoole"],
+      "prBodyNotes": [
+        ":warning: CI does not verify if extension can be built successfully or compatible. Build log review at platform.sh is required."
+      ]
+    },
+    {
+      "matchFiles": [".platform.app.yaml"],
+      "matchDepNames": ["php/php-src"],
+      "groupName": "PHP",
+      "prBodyNotes": [
+        ":warning: PHP version might not be available at platform.sh. See https://docs.platform.sh/languages/php.html#supported-versions"
+      ]
     }
   ],
   "regexManagers": [
@@ -19,21 +35,14 @@
       "matchStrings": [" OPENSWOOLE_VERSION=(?<currentValue>.*)\\n"],
       "depNameTemplate": "openswoole/ext-openswoole",
       "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$",
-      "prBodyNotes": [
-        ":warning: CI does not verify if extension can be built successfully or compatible. Build log review at platform.sh is required."
-      ]
+      "extractVersionTemplate": "^v(?<version>.*)$"
     },
     {
       "fileMatch": ["^.platform.app.yaml$"],
       "matchStrings": ["\\ntype: php:(?<currentValue>.*)\\n"],
       "depNameTemplate": "php/php-src",
       "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^php-(?<version>\\d+\\.\\d+)",
-      "groupName": "PHP",
-      "prBodyNotes": [
-        ":warning: PHP version might not be available at platform.sh. See https://docs.platform.sh/languages/php.html#supported-versions"
-      ]
+      "extractVersionTemplate": "^php-(?<version>\\d+\\.\\d+)"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     },
     {
       "matchFiles": [".platform.app.yaml"],
-      "matchDepNames": ["openswoole/ext-openswoole"],
+      "matchPackageNames": ["openswoole/ext-openswoole"],
       "extends": [":automergeDisabled", ":automergePr", ":label(Awaiting Maintainer Response)"],
       "prBodyNotes": [
         ":warning: CI does not verify if extension can be built successfully or compatible. Build log review at platform.sh is required."
@@ -23,9 +23,10 @@
     },
     {
       "matchFiles": [".platform.app.yaml"],
-      "matchDepNames": ["php/php-src"],
+      "matchPackageNames": ["php/php-src"],
       "extends": [":automergeDisabled", ":automergePr", ":label(Awaiting Maintainer Response)"],
       "groupName": "PHP",
+      "commitMessageTopic": "platform.sh PHP",
       "prBodyNotes": [
         ":warning: PHP version might not be available at platform.sh. See https://docs.platform.sh/languages/php.html#supported-versions"
       ]

--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,33 @@
     {
       "matchDepTypes": ["require"],
       "rangeStrategy": "bump"
+    },
+    {
+      "matchPackageNames": ["php"],
+      "rangeStrategy": "replace"
+    }
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^.platform.app.yaml$"],
+      "matchStrings": [" OPENSWOOLE_VERSION=(?<currentValue>.*)$"],
+      "depNameTemplate": "openswoole/ext-openswoole",
+      "datasourceTemplate": "github-releases",
+      "extractVersion": "^v(?<version>.*)$",
+      "prBodyNotes": [
+        ":warning: CI does not verify if extension can be built successfully or compatible. Build log review at platform.sh is required."
+      ]
+    },
+    {
+      "fileMatch": ["^.platform.app.yaml$"],
+      "matchStrings": ["^type: php:(?<currentValue>.*)$"],
+      "depNameTemplate": "php/php-src",
+      "datasourceTemplate": "github-tags",
+      "extractVersion": "^php-(?<version>\\d+\\.\\d+)",
+      "groupName": "PHP",
+      "prBodyNotes": [
+        ":warning: PHP version might not be available at platform.sh. See https://docs.platform.sh/languages/php.html#supported-versions"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
   "regexManagers": [
     {
       "fileMatch": ["^.platform.app.yaml$"],
-      "matchStrings": [" OPENSWOOLE_VERSION=(?<currentValue>.*)$"],
+      "matchStrings": [" OPENSWOOLE_VERSION=(?<currentValue>.*)\\n"],
       "depNameTemplate": "openswoole/ext-openswoole",
       "datasourceTemplate": "github-releases",
       "extractVersion": "^v(?<version>.*)$",
@@ -26,7 +26,7 @@
     },
     {
       "fileMatch": ["^.platform.app.yaml$"],
-      "matchStrings": ["^type: php:(?<currentValue>.*)$"],
+      "matchStrings": ["\\ntype: php:(?<currentValue>.*)\\n"],
       "depNameTemplate": "php/php-src",
       "datasourceTemplate": "github-tags",
       "extractVersion": "^php-(?<version>\\d+\\.\\d+)",

--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,7 @@
       "matchStrings": [" OPENSWOOLE_VERSION=(?<currentValue>.*)\\n"],
       "depNameTemplate": "openswoole/ext-openswoole",
       "datasourceTemplate": "github-releases",
-      "extractVersion": "^v(?<version>.*)$",
+      "extractVersionTemplate": "^v(?<version>.*)$",
       "prBodyNotes": [
         ":warning: CI does not verify if extension can be built successfully or compatible. Build log review at platform.sh is required."
       ]
@@ -29,7 +29,7 @@
       "matchStrings": ["\\ntype: php:(?<currentValue>.*)\\n"],
       "depNameTemplate": "php/php-src",
       "datasourceTemplate": "github-tags",
-      "extractVersion": "^php-(?<version>\\d+\\.\\d+)",
+      "extractVersionTemplate": "^php-(?<version>\\d+\\.\\d+)",
       "groupName": "PHP",
       "prBodyNotes": [
         ":warning: PHP version might not be available at platform.sh. See https://docs.platform.sh/languages/php.html#supported-versions"


### PR DESCRIPTION
Renovate configuration for this application changed to bump required dependencies.

This reverts php specifically back to replace strategy.
Additionally, regex manager is configured to bump php version used at platfrom.sh. It is set to group with php updates in composer. Please do note that platform.sh version for php is not really a php version selector but base runtime image selector. It is likely not to be available immediately on php release. Renovate is configured with PR note to remind of that.

Another regex manager configuration is set to suggest updates for openswoole version installed at platform.sh. That version is installed during platform.sh build and can not be tested in CI. PR note added as well.

Specific version of openswoole extension could not be requested in .laminas-ci.json. CI currently does not check where requested openswoole version is compatible.