### PR TITLE
Exclude prereleases in renovate version extract regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -46,7 +46,7 @@
       "matchStrings": ["\\ntype: php:(?<currentValue>.*)\\n"],
       "depNameTemplate": "php/php-src",
       "datasourceTemplate": "github-tags",
-      "extractVersionTemplate": "^php-(?<version>\\d+\\.\\d+)",
+      "extractVersionTemplate": "^php-(?<version>\\d+\\.\\d+)\\.\\d+$",
       "versioningTemplate": "semver-coerced"
     }
   ]


### PR DESCRIPTION
I did not consider that version extract release regex drops patch and pre-release suffixes with it so renovate is not aware of pre-releases and would suggest updates when those are found.

This changes the regex so it won't match pre-release tags.