### PR TITLE
Force symfony console downgrade to v6 for global composer install

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -11,6 +11,7 @@ build:
 
 dependencies:
   php:
+    symfony/console: "^6"
     composer/composer: "^2"
 
 mounts:


### PR DESCRIPTION
Composer 2.6.5 allows symfony console 7 but is not actually compatible with it. Until Composer 2.7 is out force symfony console to version 6 to fix platformsh builds

See https://github.com/composer/composer/issues/11736