### PR TITLE
Drop config provider for removed transient dependency

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -19,7 +19,6 @@ $aggregator = new ConfigAggregator([
     Mezzio\Hal\ConfigProvider::class,
     Laminas\Diactoros\ConfigProvider::class,
     Mezzio\Plates\ConfigProvider::class,
-    Laminas\I18n\ConfigProvider::class,
     Laminas\Validator\ConfigProvider::class,
     Phly\EventDispatcher\ConfigProvider::class,
     Mezzio\ConfigProvider::class,


### PR DESCRIPTION
#55 Removed transient package dependency but config provider reference remained unnoticed.