### PR TITLE
Fix error template failing to render

### DIFF
--- a/templates/error/error.phtml
+++ b/templates/error/error.phtml
@@ -9,7 +9,7 @@
         <a href="/chat">contact us via chat</a>.
     </p>
 
-    <?php if ($error) : ?>
+    <?php if (! empty($error)) : ?>
     <pre><?= $this->e($error) ?></pre>
     <?php endif ?>
 </section>


### PR DESCRIPTION
`$error` in the template is not defined outside outside of debug mode. With registered error handler converting warnings to exceptions error template fails to render entirely.

Replace conditional with explicit empty check.

