### PR TITLE
Fix wrong layout name in the template

### DIFF
--- a/templates/app/home-page.phtml
+++ b/templates/app/home-page.phtml
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * @var League\Plates\Template\Template $this
  */
 
-$this->layout('layout::default', ['redirect' => true]);
+$this->layout('layout::layout', ['redirect' => true]);
 ?>
 
 <div class="row">


### PR DESCRIPTION
This fixes reference to non-existing layout in home page template introduced by #63 
