### PR TITLE
Ensure $error is set before using it

### DIFF
--- a/templates/error/error.phtml
+++ b/templates/error/error.phtml
@@ -9,7 +9,7 @@
         <a href="/chat">contact us via chat</a>.
     </p>
 
-    <?php if (! empty($error)) : ?>
+    <?php if (isset($error)) : ?>
     <pre><?= $this->e($error) ?></pre>
     <?php endif ?>
 </section>


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

The variable is undefined when debug is off, which means that this template itself results in an error. Changed conditional to use `isset()` instead.
