### PR TITLE
Add common hashtags to release "toots" on Mastodon

### DIFF
--- a/src/GitHub/Listener/GitHubReleaseMastodonListener.php
+++ b/src/GitHub/Listener/GitHubReleaseMastodonListener.php
@@ -9,13 +9,15 @@ use App\Mastodon\MastodonClient;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
+use function implode;
 use function in_array;
 use function sprintf;
+use function str_contains;
 use function str_replace;
 
 class GitHubReleaseMastodonListener
 {
-    private const TOOT_TEMPLATE = "Released: {package} {version}\n\n{url}";
+    private const TOOT_TEMPLATE = "Released: {package} {version}\n{hashtags}\n\n{url}";
 
     public function __construct(
         private MastodonClient $mastodonClient,
@@ -34,9 +36,21 @@ class GitHubReleaseMastodonListener
             return;
         }
 
+        $hashtags = ['#php'];
+
+        if (str_contains($message->getPackage(), 'mezzio')) {
+            $hashtags[] = '#mezzio';
+        }
+
+        if (str_contains($message->getPackage(), 'laminas')) {
+            $hashtags[] = '#laminas';
+        }
+
+        $hashtags = implode(' ', $hashtags);
+
         $toot = str_replace(
-            ['{package}',             '{version}',             '{url}'],
-            [$message->getPackage(),  $message->getVersion(),  $message->getUrl()],
+            ['{package}',             '{version}',             '{url}',            '{hashtags}'],
+            [$message->getPackage(),  $message->getVersion(),  $message->getUrl(), $hashtags],
             self::TOOT_TEMPLATE
         );
 

--- a/test/GitHub/Listener/GitHubReleaseMastodonListenerTest.php
+++ b/test/GitHub/Listener/GitHubReleaseMastodonListenerTest.php
@@ -7,20 +7,16 @@ namespace AppTest\GitHub\Listener;
 use App\GitHub\Event\GitHubRelease;
 use App\GitHub\Listener\GitHubReleaseMastodonListener;
 use App\Mastodon\MastodonClient;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 
 class GitHubReleaseMastodonListenerTest extends TestCase
 {
-    /** @var GitHubReleaseMastodonListener */
-    private $listener;
-
-    /** @var LoggerInterface */
-    private $logger;
-
-    /** @var MastodonClient */
-    private $mastodon;
+    private GitHubReleaseMastodonListener $listener;
+    private LoggerInterface&MockObject $logger;
+    private MastodonClient&MockObject $mastodon;
 
     public function setUp(): void
     {
@@ -65,7 +61,7 @@ class GitHubReleaseMastodonListenerTest extends TestCase
 
         $this->mastodon
             ->expects($this->once())
-            ->method('statusesUpdate')->with("Released: laminas/some-component 2.3.4p8\n\nrelease-url")
+            ->method('statusesUpdate')->with("Released: laminas/some-component 2.3.4p8\n#php #laminas\n\nrelease-url")
             ->willThrowException(new RuntimeException('Error tooting release'));
 
         $this->logger
@@ -92,7 +88,7 @@ class GitHubReleaseMastodonListenerTest extends TestCase
         $this->mastodon
             ->expects($this->once())
             ->method('statusesUpdate')
-            ->with("Released: laminas/some-component 2.3.4p8\n\nrelease-url")
+            ->with("Released: laminas/some-component 2.3.4p8\n#php #laminas\n\nrelease-url")
             ->willReturn('The response-body from Mastodon that is never to be used');
 
         $this->logger


### PR DESCRIPTION
Updates the "toot" template to include `#php` and either `#laminas` or `#mezzio` depending on the package